### PR TITLE
Display members by selected interval

### DIFF
--- a/frontend/src/components/team-area/TeamArea.tsx
+++ b/frontend/src/components/team-area/TeamArea.tsx
@@ -4,19 +4,30 @@ import { ReactComponent as FilterIcon } from 'assets/icon-filter-members.svg';
 import { Teammate } from '../team-teammate/Teammate';
 import { useState } from 'react';
 import { useSelector } from 'src/services/hooks';
-import { selectMembers } from 'src/services/api/team/teamSlice';
+import {
+  selectIntervals,
+  selectMembers,
+  selectSelectedInterval,
+} from 'src/services/api/team/teamSlice';
 import { formatPhoneNumber } from 'src/utils/formatting';
 import { selectAuthData } from 'src/services/api/auth/authSlice';
 import { UserType } from 'src/services/api/auth/authTypes';
 
 export const TeamArea = (): JSX.Element => {
-  const members = useSelector(selectMembers);
+  const allMembers = useSelector(selectMembers);
+  const selectedIntervalIndex = useSelector(selectSelectedInterval);
+  const intervals = useSelector(selectIntervals);
   const authData = useSelector(selectAuthData);
   const [isAllChecked, setIsAllChecked] = useState(false);
 
   const handlerAllChecked = () => {
     setIsAllChecked(!isAllChecked);
   };
+
+  const members =
+    selectedIntervalIndex === undefined
+      ? allMembers
+      : intervals[selectedIntervalIndex].members;
 
   const sortedMembersWithFirstCurUser: UserType[] = members
     .slice()

--- a/frontend/src/components/team-intersections/TeamIntersections.tsx
+++ b/frontend/src/components/team-intersections/TeamIntersections.tsx
@@ -2,49 +2,40 @@ import clsx from 'clsx';
 import styles from './TeamIntersections.module.scss';
 import { TeamIntersectionsComponent } from '../team-intersections-component/TeamIntersectionsComponent';
 import { barSettings } from './barSettings';
-import { useMemo, useState } from 'react';
-import { useSelector } from 'src/services/hooks';
+import { useMemo } from 'react';
+import { useDispatch, useSelector } from 'src/services/hooks';
 import {
+  resetSelectedInterval,
+  selectInterval,
   selectIntervals,
   selectMembers,
+  selectSelectedInterval,
 } from 'src/services/api/team/teamSlice';
 
 export const TeamIntersections = (): JSX.Element => {
-  const [selectedIntersectionIndex, setSelectedIntersectionIndex] = useState<
-    number | null
-  >(null);
+  const selectedIntervalIndex = useSelector(selectSelectedInterval);
   const intervals = useSelector(selectIntervals);
   const members = useSelector(selectMembers);
-
-  //преобразование интервалов из типа IntervalsType[] (так приходят от api) в удобный тип - массив
-  const intervalsArray = useMemo(() => {
-    return intervals.map((interval) => {
-      return {
-        time: Object.keys(interval)[0],
-        members: interval[Object.keys(interval)[0]].members,
-        membersCount: interval[Object.keys(interval)[0]].members_count,
-      };
-    });
-  }, [intervals]);
+  const dispatch = useDispatch();
 
   //маскимальное количество участников во всех интервалах
   const maxNumberOfMembers: number = useMemo(() => {
-    return intervalsArray.reduce((curMaxValue, curIntersection) => {
+    return intervals.reduce((curMaxValue, curIntersection) => {
       if (curMaxValue > curIntersection.membersCount) {
         return curMaxValue;
       }
       return curIntersection.membersCount;
     }, 0);
-  }, [intervalsArray]);
+  }, [intervals]);
 
   return (
     <div className={clsx('team__element', styles.intersections)}>
       <div className={styles.intersections__header}>
         <h3 className={styles.intersections__title}>Пересечение по времени</h3>
-        {selectedIntersectionIndex !== null && (
+        {selectedIntervalIndex !== undefined && (
           <button
             className={styles.intersections__filterBtn}
-            onClick={() => setSelectedIntersectionIndex(null)}
+            onClick={() => dispatch(resetSelectedInterval())}
           >
             Сбросить фильтр
           </button>
@@ -52,16 +43,16 @@ export const TeamIntersections = (): JSX.Element => {
       </div>
 
       {members.length > 1 ? (
-        intervalsArray.map((intersection, index) => (
+        intervals.map((intersection, index) => (
           <TeamIntersectionsComponent
             width={(intersection.membersCount / maxNumberOfMembers) * 100 + '%'}
             background={barSettings.color[index]}
             total={intersection.membersCount}
             time={intersection.time}
             key={index}
-            isActive={index === selectedIntersectionIndex}
+            isActive={index === selectedIntervalIndex}
             onClick={() => {
-              setSelectedIntersectionIndex(index);
+              dispatch(selectInterval(index));
             }}
           />
         ))

--- a/frontend/src/services/api/team/teamAPI.ts
+++ b/frontend/src/services/api/team/teamAPI.ts
@@ -1,6 +1,11 @@
 import { request } from '../apiRequest';
 import { getRouteMemberAdd, getRouteMembers } from '../types';
-import { AddMemberRequestData, TeamResponseData } from './teamTypes';
+import {
+  AddMemberRequestData,
+  IntervalType,
+  ResponseIntervalType,
+  TeamResponseData,
+} from './teamTypes';
 
 export const teamAPI = {
   addMember: (
@@ -16,3 +21,15 @@ export const teamAPI = {
     return request.get<TeamResponseData>(getRouteMembers(projectId));
   },
 };
+
+export function createArrayFromIntervals(
+  intervals: ResponseIntervalType[],
+): IntervalType[] {
+  return intervals.map((interval) => {
+    return {
+      time: Object.keys(interval)[0],
+      members: interval[Object.keys(interval)[0]].members,
+      membersCount: interval[Object.keys(interval)[0]].members_count,
+    };
+  });
+}

--- a/frontend/src/services/api/team/teamTypes.ts
+++ b/frontend/src/services/api/team/teamTypes.ts
@@ -4,15 +4,21 @@ export type AddMemberRequestData = {
   email: string;
 };
 
-export type IntervalType = {
+export type ResponseIntervalType = {
   [time: string]: {
     members_count: number;
     members: UserType[];
   };
 };
 
+export type IntervalType = {
+  time: string;
+  membersCount: number;
+  members: UserType[];
+};
+
 export type TeamResponseData = {
   total_members: number;
   members: UserType[];
-  members_per_interval: IntervalType[];
+  members_per_interval: ResponseIntervalType[];
 };


### PR DESCRIPTION
Теперь при клике на интервал отображаются участники из этого интервала. При клике на кнопку сбросить фильтр отображаются все участники проекта.

Перенесла код, преобразующий тип интервала из компонента TeamIntersections в слайс команды, чтобы преобразование происходило в момент получения данных.

Сейчас **не отображаются фотографии** участников из одного интервала, потому что с бэка не приходит поле с фотографией. 
**Время работы отображается в другом формате (с секундами)**, потому что так приходит с бэка. Это можно поправить на фронте, но я надеюсь не придется. Попросила поправить Александра